### PR TITLE
Use normalized armature coords as primary features, not angles

### DIFF
--- a/bokeh_functions.py
+++ b/bokeh_functions.py
@@ -547,20 +547,20 @@ def build_bokeh_app(
             target_frameno = comparison_poses[0]["frameno"]
             target_poseno = comparison_poses[0]["poseno"]
 
-            # If we want to use normalized armature coordinates instead
-            # target_pose_w_confs = shift_normalize_rescale_pose_coords(
-            #     pose_data[target_frameno]["predictions"][target_poseno]
-            # )
-            # target_pose = extract_trustworthy_coords(target_pose_w_confs)
-            # target_pose_query = np.array([np.nan_to_num(target_pose, nan=-1)]).astype(
-            #     "float32"
-            # )
-
-            target_pose = pose_angle_data[target_frameno]["predictions"][target_poseno]
-
-            target_pose_query = np.array([np.nan_to_num(target_pose, nan=-999)]).astype(
+            # Using normalized armature coordinates as primary features
+            target_pose_w_confs = shift_normalize_rescale_pose_coords(
+                pose_data[target_frameno]["predictions"][target_poseno]
+            )
+            target_pose = extract_trustworthy_coords(target_pose_w_confs)
+            target_pose_query = np.array([np.nan_to_num(target_pose, nan=-1)]).astype(
                 "float32"
             )
+
+            # Using pose angles as primary features
+            # target_pose = pose_angle_data[target_frameno]["predictions"][target_poseno]
+            # target_pose_query = np.array([np.nan_to_num(target_pose, nan=-999)]).astype(
+            #     "float32"
+            # )
 
             D, I = faiss_ip_index.search(target_pose_query, SIMILAR_MATCHES_TO_FIND)
 
@@ -576,21 +576,21 @@ def build_bokeh_app(
                     match_frameno = normalized_pose_metadata[match_index]["frameno"]
                     match_poseno = normalized_pose_metadata[match_index]["poseno"]
 
-                    # If we want to use normalized armature coordinates instead
-                    # comparison_similarity = compare_poses_cosine(
-                    #     target_pose_w_confs,
-                    #     shift_normalize_rescale_pose_coords(
-                    #         pose_data[match_frameno]["predictions"][match_poseno]
-                    #     ),
-                    # )
-
-                    match_pose = pose_angle_data[match_frameno]["predictions"][
-                        match_poseno
-                    ]
-
-                    comparison_similarity = compare_poses_angles(
-                        target_pose, match_pose
+                    # Using normalized armature coordinates as primary features
+                    comparison_similarity = compare_poses_cosine(
+                        target_pose_w_confs,
+                        shift_normalize_rescale_pose_coords(
+                            pose_data[match_frameno]["predictions"][match_poseno]
+                        ),
                     )
+
+                    # Using pose angles as primary features
+                    # match_pose = pose_angle_data[match_frameno]["predictions"][
+                    #     match_poseno
+                    # ]
+                    # comparison_similarity = compare_poses_angles(
+                    #     target_pose, match_pose
+                    # )
 
                     match_similarities[match_index] = comparison_similarity
 

--- a/video_posedata_explorer.ipynb
+++ b/video_posedata_explorer.ipynb
@@ -92,6 +92,8 @@
     "video_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))\n",
     "cap.release()\n",
     "\n",
+    "print(\"Video dimensions:\",video_width,\"(w) x\",video_height,\"(h)\")\n",
+    "\n",
     "print(\"Video FPS:\", video_fps)\n",
     "\n",
     "print(\"Loading video and JSON files, please wait...\")\n",
@@ -140,10 +142,18 @@
     "\n",
     "print(\"Indexing video posedata set for similarity search\")\n",
     "\n",
+    "# Using normalized armature coordiantes as primary features\n",
     "faiss_pose_data = [\n",
-    "    tuple(np.nan_to_num(angles, nan=-999).tolist()) for angles in pose_angles\n",
+    "    tuple(np.nan_to_num(raw_pose, nan=-1).tolist()) for raw_pose in normalized_poses\n",
     "]\n",
-    "faiss_IP_index = faiss.IndexFlatIP(28)\n",
+    "faiss_IP_index = faiss.IndexFlatIP(34) # If using normalized coords, rather than angles\n",
+    "\n",
+    "# Using pose angles as primary features\n",
+    "# faiss_pose_data = [\n",
+    "#     tuple(np.nan_to_num(angles, nan=-999).tolist()) for angles in pose_angles\n",
+    "# ]\n",
+    "# faiss_IP_index = faiss.IndexFlatIP(28)\n",
+    "\n",
     "faiss_IP_input = np.array(faiss_pose_data).astype(\"float32\")\n",
     "faiss.normalize_L2(faiss_IP_input)  # Must normalize the inputs!\n",
     "faiss_IP_index.add(faiss_IP_input)\n"
@@ -196,7 +206,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -254,13 +263,6 @@
     "\n",
     "show(bkapp, notebook_url=f\"localhost:{bokeh_port}\")\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {},


### PR DESCRIPTION
This reverts the pose indexing and comparison approach to the previous method based on normalized armature coordinates. The method based on joint angles needs further refinement.